### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca"
 
 # title
-ENV TITLE=OpenShot
+ENV TITLE=OpenShot \
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **22.09.25:** - Rebase to Debian Trixie.
 * **29.07.25:** - Rebase to selkies. Breaking Change: HTTPS is now required. Either use a reverse proxy (like SWAG) with SSL cert or direct connect to port 3001 with HTTPS.
 * **23.12.24:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -104,6 +104,7 @@ init_diagram: |
   "openshot:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}
   - {date: "29.07.25:", desc: "Rebase to selkies. Breaking Change: HTTPS is now required. Either use a reverse proxy (like SWAG) with SSL cert or direct connect to port 3001 with HTTPS."}
   - {date: "23.12.24:", desc: "Initial release."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,0 +1,1 @@
+/opt/openshot/usr/bin/openshot-qt-launch

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openbox_menu xmlns="http://openbox.org/3.4/menu">
+<menu id="root-menu" label="MENU">
+<item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
+<item label="OpenShot" icon="/usr/share/icons/hicolor/scalable/apps/openshot-qt.svg"><action name="Execute"><command>/opt/openshot/usr/bin/openshot-qt-launch</command></action></item>
+</menu>
+</openbox_menu>


### PR DESCRIPTION
This adds wayland init and makes it default. Only real bug is fullscreen actually works in wayland as it is authoritative so the error popup occupies the whole screen on first launch. 